### PR TITLE
Do some rewriting of equivalent booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,17 +547,9 @@ toCounterContext gridContext =
       isBlack =
         if gridContext.row % 2 == 0
         then
-          if gridContext.column % 2 == 0
-          then
-            True
-          else
-            False
+          gridContext.column % 2 == 0
         else
-          if gridContext.column % 2 == 0
-          then
-            False
-          else
-            True
+          not (gridContext.column % 2 == 0)
 
       (textColor, backgroundColor) =
         if isBlack


### PR DESCRIPTION
Whenever your branches are bools, you can probably not have branches. If I am understanding things correctly, the shortest version is this:

``` elm
(gridContext.row % 2 == 0) == (gridContext.column % 2 == 0)
```

Meaning they are both even or they are both odd.
