### PR TITLE
Fix checkerboard image in  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 In this tutorial, we'll see how we can make a [checkerboard](https://en.wikipedia.org/wiki/Checkerboard) grid in Elm where each cell contains an independent, self-updating counter.
 
-![Image of Checkerboard Grid of Counters]
-(/checkerboard.png)
+![Image of Checkerboard Grid of Counters](checkerboard.png)
 
 The goal is to understand more about the [Elm Architecture](http://elm-lang.org/guide/architecture) by exploring container components and how to handle problems such as layout and update when dealing with nested components.
 


### PR DESCRIPTION
The markdown had a line break causing the image to not show.